### PR TITLE
Bumping Major Dependency Versions

### DIFF
--- a/Framework/AppiumUnitTests/AppiumUnitTests.csproj
+++ b/Framework/AppiumUnitTests/AppiumUnitTests.csproj
@@ -15,8 +15,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>

--- a/Framework/BaseDatabaseTest/BaseDatabaseTest.csproj
+++ b/Framework/BaseDatabaseTest/BaseDatabaseTest.csproj
@@ -49,13 +49,13 @@
 	<ItemGroup>
 		<PackageReference Include="Dapper" Version="2.0.123" />
 		<PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="6.0.4" />
+		<PackageReference Include="Microsoft.Data.Sqlite.Core" Version="6.0.9" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Npgsql" Version="6.0.4" />
-		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.0.7" />
+		<PackageReference Include="Npgsql" Version="6.0.7" />
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.2" />
 		<PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
 	</ItemGroup>
 

--- a/Framework/BaseEmailTest/BaseEmailTest.csproj
+++ b/Framework/BaseEmailTest/BaseEmailTest.csproj
@@ -47,7 +47,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MailKit" Version="3.2.0" />
+		<PackageReference Include="MailKit" Version="3.4.1" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Framework/BaseMongoTest/BaseMongoTest.csproj
+++ b/Framework/BaseMongoTest/BaseMongoTest.csproj
@@ -53,9 +53,9 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="MongoDB.Bson" Version="2.15.0" />
-		<PackageReference Include="MongoDB.Driver" Version="2.15.0" />
-		<PackageReference Include="MongoDB.Driver.Core" Version="2.15.0" />
+		<PackageReference Include="MongoDB.Bson" Version="2.17.1" />
+		<PackageReference Include="MongoDB.Driver" Version="2.17.1" />
+		<PackageReference Include="MongoDB.Driver.Core" Version="2.17.1" />
 		<PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
 	</ItemGroup>
 

--- a/Framework/BasePlaywrightTest/BasePlaywrightTest.csproj
+++ b/Framework/BasePlaywrightTest/BasePlaywrightTest.csproj
@@ -54,7 +54,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Playwright" Version="1.21.0" />
+		<PackageReference Include="Microsoft.Playwright" Version="1.26.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Framework/BasePlaywrightTest/BasePlaywrightTest.csproj
+++ b/Framework/BasePlaywrightTest/BasePlaywrightTest.csproj
@@ -54,7 +54,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Playwright" Version="1.26.0" />
+		<PackageReference Include="Microsoft.Playwright" Version="1.21.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Framework/BaseSeleniumTest/ActionBuilder.cs
+++ b/Framework/BaseSeleniumTest/ActionBuilder.cs
@@ -122,12 +122,7 @@ namespace CognizantSoftvision.Maqs.BaseSeleniumTest
         public static void DragAndDropToOffset(IWebElement source, IWebElement destination, int pixelsXOffset, int pixelsYOffset)
         {
             Actions builder = new Actions(SeleniumUtilities.SearchContextToWebDriver(source));
-
-            // Move to element goes to the top left corner so compensate for that 
-            int horizontalOffset = (destination.Size.Width / 2) + pixelsXOffset;
-            int verticalOffset = (destination.Size.Height / 2) + pixelsYOffset;
-
-            builder.ClickAndHold(source).MoveToElement(destination, horizontalOffset, verticalOffset).Release().Build().Perform();
+            builder.ClickAndHold(source).MoveToElement(destination, pixelsXOffset, pixelsYOffset).Release().Build().Perform();
         }
 
         /// <summary>

--- a/Framework/BaseSeleniumTest/BaseSeleniumTest.csproj
+++ b/Framework/BaseSeleniumTest/BaseSeleniumTest.csproj
@@ -53,12 +53,11 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Selenium.Axe" Version="3.1.5" />
-		<PackageReference Include="Selenium.Support" Version="4.1.1" />
-		<PackageReference Include="Selenium.WebDriver" Version="4.1.1" />
+		<PackageReference Include="Selenium.Axe" Version="4.0.2" />
+		<PackageReference Include="Selenium.Support" Version="4.5.0" />
+		<PackageReference Include="Selenium.WebDriver" Version="4.5.0" />
 		<PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />
-		<PackageReference Include="WebDriverManager" Version="2.12.4" />
-		<PackageReference Include="WebDriverManager" Version="2.12.4" />
+		<PackageReference Include="WebDriverManager" Version="2.16.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Framework/BaseSeleniumTest/Extensions/AbstractLazyIWebElement.cs
+++ b/Framework/BaseSeleniumTest/Extensions/AbstractLazyIWebElement.cs
@@ -783,17 +783,6 @@ namespace CognizantSoftvision.Maqs.BaseSeleniumTest.Extensions
         }
 
         /// <summary>
-        /// Gets the value of a JavaScript property of this element
-        /// </summary>
-        /// <param name="propertyName">The name JavaScript the JavaScript property to get the value of</param>
-        /// <returns> The JavaScript property's current value. Returns a null if the value is not set or the property does not exist</returns>
-        [Obsolete("Use the GetDomProperty method instead.")]
-        public string GetProperty(string propertyName)
-        {
-            return this.GetRawExistingElement().GetProperty(propertyName);
-        }
-
-        /// <summary>
         /// Finds the first OpenQA.Selenium.IWebElement using the given method.
         /// </summary>
         /// <param name="by">The locating mechanism to use</param>

--- a/Framework/BaseTestUnitTests/BaseTestUnitTests.csproj
+++ b/Framework/BaseTestUnitTests/BaseTestUnitTests.csproj
@@ -15,12 +15,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 

--- a/Framework/BaseWebServiceTest/BaseWebServiceTest.csproj
+++ b/Framework/BaseWebServiceTest/BaseWebServiceTest.csproj
@@ -49,7 +49,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.8" />
+		<PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Framework/CompositeUnitTests/CompositeUnitTests.csproj
+++ b/Framework/CompositeUnitTests/CompositeUnitTests.csproj
@@ -15,13 +15,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 

--- a/Framework/DatabaseUnitTests/DatabaseUnitTests.csproj
+++ b/Framework/DatabaseUnitTests/DatabaseUnitTests.csproj
@@ -15,13 +15,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 

--- a/Framework/EmailUnitTests/EmailUnitTests.csproj
+++ b/Framework/EmailUnitTests/EmailUnitTests.csproj
@@ -25,12 +25,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 

--- a/Framework/FrameworkUnitTests/FrameworkUnitTests.csproj
+++ b/Framework/FrameworkUnitTests/FrameworkUnitTests.csproj
@@ -12,9 +12,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 

--- a/Framework/MongoDBUnitTests/MongoDBUnitTests.csproj
+++ b/Framework/MongoDBUnitTests/MongoDBUnitTests.csproj
@@ -15,12 +15,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 

--- a/Framework/PlaywrightTests/PlaywrightTests.csproj
+++ b/Framework/PlaywrightTests/PlaywrightTests.csproj
@@ -11,8 +11,8 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 	  </PackageReference>
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-	  <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+	  <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
 	  <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 

--- a/Framework/SeleniumUnitTests/LazyElementUnitTests.cs
+++ b/Framework/SeleniumUnitTests/LazyElementUnitTests.cs
@@ -799,18 +799,6 @@ namespace SeleniumUnitTests
         }
 
         /// <summary>
-        /// Verify Lazy Element property
-        /// </summary>
-        [TestMethod]
-        [TestCategory(TestCategories.Selenium)]
-        public void LazyElementProperty()
-        {
-#pragma warning disable CS0618 // Type or member is obsolete
-            Assert.AreEqual("showDialog1", this.DialogOneButton.GetProperty("id"), "Expected ID to be 'showDialog1'");
-#pragma warning restore CS0618 // Type or member is obsolete
-        }
-
-        /// <summary>
         /// Verify Lazy Element DOM property
         /// </summary>
         [TestMethod]
@@ -1185,7 +1173,6 @@ namespace SeleniumUnitTests
             a1.SendKeys(rawElement, "Hello").Build().Perform();
             a1.MoveToElement(rawElement).Build().Perform();
             a1.MoveToElement(rawElement, 0, 0).Build().Perform();
-            a1.MoveToElement(rawElement, 0, 0, MoveToElementOffsetOrigin.Center).Build().Perform();
         }
 
         /// <summary>
@@ -1196,14 +1183,12 @@ namespace SeleniumUnitTests
         public void LazyElementFindRawElementsWorksWithActions()
         {
             IWebElement rawElement = this.DivRoot.FindRawElements(this.DisabledItem.By)[0];
-
             Actions a1 = new Actions(this.WebDriver);
             a1.KeyDown(rawElement, Keys.Shift).Build().Perform();
             a1.KeyUp(rawElement, Keys.Shift).Build().Perform();
             a1.SendKeys(rawElement, "Hello").Build().Perform();
             a1.MoveToElement(rawElement).Build().Perform();
             a1.MoveToElement(rawElement, 0, 0).Build().Perform();
-            a1.MoveToElement(rawElement, 0, 0, MoveToElementOffsetOrigin.Center).Build().Perform();
         }
 
         /// <summary>

--- a/Framework/SeleniumUnitTests/SauceLabsBaseSeleniumTest.cs
+++ b/Framework/SeleniumUnitTests/SauceLabsBaseSeleniumTest.cs
@@ -29,7 +29,6 @@ namespace SeleniumUnitTests
 
                 var browserOptions = new ChromeOptions
                 {
-                    UseSpecCompliantProtocol = true,
                     PlatformName = "Windows 10",
                     BrowserVersion = "latest"
                 };

--- a/Framework/SeleniumUnitTests/SeleniumUnitTests.csproj
+++ b/Framework/SeleniumUnitTests/SeleniumUnitTests.csproj
@@ -15,14 +15,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="Titanium.Web.Proxy" Version="3.1.1397" />
+    <PackageReference Include="Titanium.Web.Proxy" Version="3.1.1450" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Framework/SpecFlowExtension/SpecFlowExtension.csproj
+++ b/Framework/SpecFlowExtension/SpecFlowExtension.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="MSTest.TestFramework" version="2.2.10" />
     <PackageReference Include="NUnit" version="3.13.3" />
     <PackageReference Include="SpecFlow" version="3.9.74" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
     <PackageReference Include="System.Reflection.Emit" version="4.7.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" version="4.7.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" version="4.5.4" />

--- a/Framework/SpecFlowExtensionNUnitTests/SpecFlowExtensionNUnitTests.csproj
+++ b/Framework/SpecFlowExtensionNUnitTests/SpecFlowExtensionNUnitTests.csproj
@@ -18,14 +18,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="SpecFlow.NUnit" Version="3.9.74" />
     <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 

--- a/Framework/SpecFlowExtensionUnitTests/SpecFlowExtensionUnitTests.csproj
+++ b/Framework/SpecFlowExtensionUnitTests/SpecFlowExtensionUnitTests.csproj
@@ -15,15 +15,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="SpecFlow.MsTest" Version="3.9.74" />
     <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.74" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 

--- a/Framework/UtilitiesUnitTests/UtilitiesUnitTests.csproj
+++ b/Framework/UtilitiesUnitTests/UtilitiesUnitTests.csproj
@@ -15,13 +15,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
   </ItemGroup>
 

--- a/Framework/WebServiceUnitTests/WebServiceUnitTests.csproj
+++ b/Framework/WebServiceUnitTests/WebServiceUnitTests.csproj
@@ -15,16 +15,16 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="Titanium.Web.Proxy" Version="3.1.1397" />
+    <PackageReference Include="Titanium.Web.Proxy" Version="3.1.1450" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
New selenium bump removed a few things completely.

- Actions only support moving to center of element, and the MoveToElementOffsetOrigin enum was removed. 
- Drag and drop by offset is affected as the location of an element is always its direct center as before it was the top left corner.
- GetProperty was deprecated and then removed.  Use GetDomProperty instead.